### PR TITLE
Update Peugeot Expert generations: Added reference and updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Peugeot Expert
 
+This repository contains signal set configurations for the Peugeot Expert, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Peugeot Expert.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Peugeot_Expert"
+
 generations:
   - name: "First Generation"
     start_year: 1995


### PR DESCRIPTION
- Added Wikipedia reference to generations.yaml
- Updated README.md with standard template
- Verified generation data against Wikipedia article confirming:
  - First Generation: 1995-2006/2007 (Peugeot launched July 1995)
  - Second Generation: 2007-2016 (joint venture ended March 2016)
  - Third Generation: 2016-present (current active generation)
